### PR TITLE
vscode geneator

### DIFF
--- a/Documentation/LuaDocGenerator.cs
+++ b/Documentation/LuaDocGenerator.cs
@@ -401,7 +401,26 @@ public static class LuaDocGenerator
                 snippets.AppendLine(finalBlock);
             }
         }
+        
+        foreach (LuaEnumInfo enumInfo in GetAllEnums())
+        {
+            foreach (LuaEnumValueInfo enumValueInfo in enumInfo.values)
+            {
+                if (enumValueInfo.Attribute != null && enumValueInfo.Attribute.hidden)
+                {
+                    continue;
+                }
+                
+                snippet.prefix = string.Format("{0}.{1}", enumInfo.Attribute.name, enumValueInfo.StringValue);
+                snippet.body[0] = snippet.prefix;
+                snippet.description = enumValueInfo.Attribute != null ? enumValueInfo.Attribute.description : string.Empty;
 
+                string finalBlock = string.Format("\"{0}\" : {1},", snippet.prefix, JsonUtility.ToJson(snippet, true));
+                
+                snippets.AppendLine(finalBlock);
+            }
+        }
+        
         EditorGUIUtility.systemCopyBuffer = snippets.ToString();
     }
 

--- a/Documentation/LuaDocGenerator.cs
+++ b/Documentation/LuaDocGenerator.cs
@@ -167,6 +167,27 @@ public static class LuaDocGenerator
 
         return result;
     }
+    
+    private class Config 
+    {
+        public string LuaProjectPath;
+    }
+
+    private static Config GetConfig() 
+    {
+        var configFile = Path.Combine(Application.dataPath, "..", ".unity-lua.json");
+        if (File.Exists(configFile)) {
+            var file = File.ReadAllText(configFile);
+            return JsonUtility.FromJson<Config>(file);
+        }
+        
+         var defaultConfig = new Config {
+            LuaProjectPath = Path.Combine(Application.dataPath, "Scripts", "Lua")
+        };
+
+        File.WriteAllText(configFile, JsonUtility.ToJson(defaultConfig));
+        return defaultConfig;
+    }
 
     /// <summary>
     /// Generate MediaWiki pages for all Lua apis and enums
@@ -420,8 +441,21 @@ public static class LuaDocGenerator
                 snippets.AppendLine(finalBlock);
             }
         }
+
+        Config config = GetConfig();
+
+        string snippetDir = Path.Combine(config.LuaProjectPath, ".vscode");
+        Directory.CreateDirectory(snippetDir);
         
-        EditorGUIUtility.systemCopyBuffer = snippets.ToString();
+        string snippetFilePath = Path.Combine(snippetDir, "lua.code-snippets");
+        
+        StreamWriter file = File.CreateText(snippetFilePath);
+        
+        file.WriteLine("{");
+        file.Write(snippets);
+        file.WriteLine("}");
+        
+        file.Close();
     }
 
     private class AtomSnippet
@@ -616,6 +650,5 @@ public static class LuaDocGenerator
 
         return result;
     }
-    
 }
 #endif // UNITY_EDITOR


### PR DESCRIPTION
- generate enum for vscode, [issue](https://github.com/Semaeopus/Unity-Lua/issues/2)
- generate vscode snippet as a file, [issue](https://github.com/Semaeopus/Unity-Lua/issues/1)

when generate, it will try to read a config file in root `/.unity-lua.json`
if there is not such file in will now error and generate that file
if there is, it will use a `LuaProjectPath` as a vscode project path and create snippet file

still a bit weird when there is no config and need to re generate to get pass error, but I'm not quite sure how should I fix it yet (maybe a new button to generate config?)
