### PR TITLE
fix: enable default modules

### DIFF
--- a/LuaVM.cs
+++ b/LuaVM.cs
@@ -66,7 +66,7 @@ public class LuaVM
     public LuaVM(VMSettings vmSettings)
     {
         m_LuaScript =
-            new Script(CoreModules.Preset_SoftSandbox)
+            new Script(CoreModules.Preset_Default)
             {
                 Options =
                 {


### PR DESCRIPTION
The `SoftSandbox` preset does not allow `require`, `load`, `loadfile`, and `dofile` functions to be used.